### PR TITLE
Update kdenlive.spec

### DIFF
--- a/kdenlive.spec
+++ b/kdenlive.spec
@@ -66,7 +66,6 @@ Requires: mlt-freeworld%{?_isa} >= %{mlt_version}
 %else
 Requires: mlt%{?_isa} >= %{mlt_version}
 %endif
-Requires: recordmydesktop
 Requires: qt5-qtquickcontrols
 
 %description
@@ -139,6 +138,9 @@ fi
 
 
 %changelog
+* Sat Mar 17 2018 René Genz <liebundartig@freenet.de> - 17.12.3-2
+- remove requirement for recordmydesktop
+
 * Sun Mar 11 2018 Sérgio Basto <sergio@serjux.com> - 17.12.3-1
 - Update kdenlive to 17.12.3
 


### PR DESCRIPTION
Installation of kdenlive fails in Fedora 28:
~~~~
$ sudo dnf install kdenlive --refresh
...
Error: 
 Problem: conflicting requests
  - nothing provides recordmydesktop needed by kdenlive-17.12.2-1.fc28.x86_64
~~~~
because recordmydesktop has been dropped in Fedora 28: https://src.fedoraproject.org/rpms/recordmydesktop/commits/master